### PR TITLE
修正 email 標題亂碼問題

### DIFF
--- a/system/libraries/Email.php
+++ b/system/libraries/Email.php
@@ -1261,7 +1261,7 @@ class CI_Email {
 
 		// Line length must not exceed 76 characters, so we adjust for
 		// a space, 7 extra characters =??Q??=, and the charset that we will add to each line
-		$limit = 75 - 7 - strlen($this->charset);
+		$limit = 200 - 7 - strlen($this->charset);
 
 		// these special characters must be converted too
 		$convert = array('_', '=', '?');


### PR DESCRIPTION
原本的長度太短了，中文會被切斷導致亂碼
